### PR TITLE
feat: skip notifcations when article is autoread

### DIFF
--- a/configure.phtml
+++ b/configure.phtml
@@ -26,6 +26,13 @@ declare(strict_types=1);
 				<input id="avatar_url" name="avatar_url" type="text" value="<?= $this->getSystemConfigurationValue("avatar_url") ?>">
 			</div>
 		</div>
+
+		<div class="form-group">
+			<label for="ignore_autoread" class="group-name">Ignore autoread</label>
+			<div class="group-controls">
+				<input id="ignore_autoread" name="ignore_autoread" type="checkbox" <?= $this->getSystemConfigurationValue("ignore_autoread", false) ? 'checked' : '' ?>>
+			</div>
+		</div>
 	</fieldset>
 
 	<div class="form-group form-actions">

--- a/extension.php
+++ b/extension.php
@@ -7,7 +7,7 @@ class DiscordExtension extends Minz_Extension {
 		#[\Override]
 		public function init(): void {
 			$this->registerTranslates();
-			$this->registerHook("entry_before_insert", [$this, "handleEntryBeforeInsert"]);
+			$this->registerHook("entry_before_add", [$this, "handleEntryBeforeAdd"]);
 		}
 
 		public function handleConfigureAction(): void {
@@ -37,31 +37,33 @@ class DiscordExtension extends Minz_Extension {
 			}
 	}
 
-	public function handleEntryBeforeInsert($entry) {
-		$this->sendMessage(
-			$this->getSystemConfigurationValue("url"),
-			$this->getSystemConfigurationValue("username"),
-			$this->getSystemConfigurationValue("avatar_url"),
-			[
-				"embeds" => [
-					[
-						"title" => $entry->title(),
-						"url" => $entry->link(),
-						"color" => 2605643,
-						"description" => $this->truncate($this->markdownify($entry->originalContent()), 2000),
-						"timestamp" => (new DateTime('@'. $entry->date(true)/1000))->format(DateTime::ATOM),
-						"author" => [
-							"name" => $entry->feed()->name(),
-							"icon_url" => $this->favicon($entry->feed()->website())
-						],
-						"footer" => [
-							"text" =>  $this->getSystemConfigurationValue("username"),
-							"icon_url" => $this->getSystemConfigurationValue("avatar_url")
+	public function handleEntryBeforeAdd($entry) {
+		if(!$entry->isRead()) {
+			$this->sendMessage(
+				$this->getSystemConfigurationValue("url"),
+				$this->getSystemConfigurationValue("username"),
+				$this->getSystemConfigurationValue("avatar_url"),
+				[
+					"embeds" => [
+						[
+							"title" => $entry->title(),
+							"url" => $entry->link(),
+							"color" => 2605643,
+							"description" => $this->truncate($this->markdownify($entry->originalContent()), 2000),
+							"timestamp" => (new DateTime('@'. $entry->date(true)/1000))->format(DateTime::ATOM),
+							"author" => [
+								"name" => $entry->feed()->name(),
+								"icon_url" => $this->favicon($entry->feed()->website())
+							],
+							"footer" => [
+								"text" =>  $this->getSystemConfigurationValue("username"),
+								"icon_url" => $this->getSystemConfigurationValue("avatar_url")
+							]
 						]
 					]
 				]
-			]
-		);
+			);
+		}
 
 		return $entry;
 	}


### PR DESCRIPTION
The current hook `entry_before_insert` runs before filter actions have been applied, which means that if an article is marked as read automatically by filter actions it will still trigger a notification.

Using the `entry_before_add` hook will solved this problem as it runs after the filter actions, just before the insertion into the database happens.

### PR Checklist
- [x] Wait for FreshRSS/FreshRSS#7977 to be released