### PR TITLE
Fix incorrect timestamp causing Discord embeds to show 1970 dates

### DIFF
--- a/extension.php
+++ b/extension.php
@@ -89,7 +89,7 @@ class DiscordExtension extends Minz_Extension
 					4000
 				),
 				"timestamp" => (new DateTime(
-					"@" . $entry->date(true) / 1000
+					"@" . ($entry->date(true) / 1000)
 				))->format(DateTime::ATOM),
 				"author" => [
 					"name" => $entry->feed()->name(),

--- a/extension.php
+++ b/extension.php
@@ -89,7 +89,7 @@ class DiscordExtension extends Minz_Extension
 					4000
 				),
 				"timestamp" => (new DateTime(
-					"@" . ($entry->date(true) / 1000)
+					"@" . $entry->date(true)
 				))->format(DateTime::ATOM),
 				"author" => [
 					"name" => $entry->feed()->name(),


### PR DESCRIPTION
**Problem**
Discord embed timestamps were displaying dates in January 1970 (e.g., "1/21/70, 5:49 AM") instead of the actual article publication date.
<img width="382" height="160" alt="image" src="https://github.com/user-attachments/assets/96b7a44e-7dd9-40e2-a840-436bc021ab2c" />

**Cause**
The code was dividing $entry->date(true) by 1000, but this method already returns a Unix timestamp in seconds (not milliseconds). Dividing by 1000 resulted in very small timestamp values that corresponded to dates shortly after the Unix epoch (January 1, 1970).

**Solution**
Removed the unnecessary division by 1000. The $entry->date(true) value can be used directly as it's already in the correct format (Unix timestamp in seconds).
<img width="380" height="158" alt="image" src="https://github.com/user-attachments/assets/c3f8f873-3ab8-4d3b-9ce6-36078eca6901" />